### PR TITLE
Update AbstractValidator.php - fixed Notice: Undefined index

### DIFF
--- a/app/code/community/Sendit/Bliskapaczka/vendor/bliskapaczkapl/bliskapaczka-api-client/src/Bliskapaczka/ApiClient/AbstractValidator.php
+++ b/app/code/community/Sendit/Bliskapaczka/vendor/bliskapaczkapl/bliskapaczka-api-client/src/Bliskapaczka/ApiClient/AbstractValidator.php
@@ -76,6 +76,7 @@ abstract class AbstractValidator
     protected function notBlank($property, $settings)
     {
         if (isset($settings['notblank'])
+            && isset($this->data[$property])
             && isset($settings['notblank']) === true
             && (is_null($this->data[$property]) || strlen($this->data[$property]) == 0)
         ) {
@@ -92,6 +93,7 @@ abstract class AbstractValidator
     protected function maxLength($property, $settings)
     {
         if (isset($settings['maxlength'])
+            && isset($this->data[$property])
             && $settings['maxlength'] > 0
             && strlen($this->data[$property]) > $settings['maxlength']
         ) {


### PR DESCRIPTION
`Bliskapaczka\ApiClient\Validator\Order\Advice.php::validationByProperty()` method checks if `$this->data[$property]` isset **AND** checks other settings, if `$settings['notblank']` is **not set OR** `$settings['notblank']` is **false**, we will get notice if `$this->data[$property]` is not set.
